### PR TITLE
Fix volume levels resetting on Windows

### DIFF
--- a/win32/win32_sound.cpp
+++ b/win32/win32_sound.cpp
@@ -22,6 +22,8 @@ CWaveOut S9xWaveOut;
 // Interface used to access the sound output
 IS9xSoundOutput *S9xSoundOutput = &S9xXAudio2;
 
+static double last_volume = 1.0;
+
 /*  ReInitSound
 reinitializes the sound core with current settings
 IN:
@@ -51,6 +53,7 @@ bool ReInitSound()
 	if(S9xSoundOutput)
 		S9xSoundOutput->DeInitSoundOutput();
 
+    last_volume = 1.0;
     return S9xInitSound(0);
 }
 
@@ -95,8 +98,6 @@ called by the sound core to process generated samples
 */
 void S9xSoundCallback(void *data)
 {
-	static double last_volume = 1.0;
-
 	// only try to change volume if we actually need to switch it
 	double current_volume = (Settings.TurboMode ? GUI.VolumeTurbo : GUI.VolumeRegular) / 100.;
 	if (last_volume != current_volume) {


### PR DESCRIPTION
The Windows version of snes9x-rr has an obnoxious bug where your volume settings are ignored any time the sound system is reinitialized.  To replicate, set your Sound -> Settings -> Volume to anything other than 100% and begin playing.  If you reset the game (or open the sound settings screen and press cancel) it will reset the volume level to 100%.

The fix for this has been cherry-picked from the upstream snes9x repo.