### PR TITLE
Fixed a compile error on g++ regarding const comparison functors in config parser

### DIFF
--- a/conffile.cpp
+++ b/conffile.cpp
@@ -452,7 +452,7 @@ void ConfigFile::ClearLines()
     }
 }
 
-bool ConfigFile::ConfigEntry::section_then_key_less::operator()(const ConfigEntry &a, const ConfigEntry &b) {
+bool ConfigFile::ConfigEntry::section_then_key_less::operator()(const ConfigEntry &a, const ConfigEntry &b) const {
 	if(curConfigFile && a.section!=b.section){
 		const int sva = curConfigFile->GetSectionSize(a.section);
 		const int svb = curConfigFile->GetSectionSize(b.section);

--- a/conffile.h
+++ b/conffile.h
@@ -90,7 +90,7 @@ class ConfigFile {
 		mutable bool used;
 
         struct section_then_key_less {
-            bool operator()(const ConfigEntry &a, const ConfigEntry &b);
+            bool operator()(const ConfigEntry &a, const ConfigEntry &b) const;
         };
 
         struct key_less {
@@ -101,7 +101,7 @@ class ConfigFile {
         };
 
         struct line_less {
-            bool operator()(const ConfigEntry &a, const ConfigEntry &b){
+            bool operator()(const ConfigEntry &a, const ConfigEntry &b) const {
 				if(a.line==b.line) return (b.val.empty() && !a.val.empty()) || a.key<b.key;
                 if(b.line<0) return true;
                 if(a.line<0) return false;


### PR DESCRIPTION
Related issue: #14 
Fails to compile on g++ due to const-ness errors.
Marked comparison functions for ConfigEntry as const.
Edit: This issue appears in the unix/ build using ./configure && make